### PR TITLE
Introduce `World` trait and make preprocessors mockable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,12 +352,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -365,6 +381,23 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
@@ -384,10 +417,15 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1177,6 +1215,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1237,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -1265,6 +1318,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1623,6 +1701,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serial_test",
  "thiserror",
  "tokio",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +1546,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "clap",
+ "derive_more",
  "itertools",
  "once_cell",
  "reqwest",
@@ -1602,6 +1624,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unscanny"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "ecow"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +344,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "futures-channel"
@@ -798,6 +810,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +977,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1330,6 +1394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thin-vec"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,6 +1618,7 @@ dependencies = [
  "clap",
  "derive_more",
  "itertools",
+ "mockall",
  "once_cell",
  "reqwest",
  "serde",
@@ -1555,6 +1626,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "typst-preprocess",
  "typst-syntax",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = "0.1.80"
 clap = { version = "4.5.7", features = ["derive", "env"] }
 derive_more = { version = "2.0.1", features = ["debug"] }
 itertools = "0.14.0"
+mockall = { version = "0.13.1", optional = true }
 once_cell = "1.19.0"
 reqwest = "0.12.5"
 serde = { version = "1.0.203", features = ["derive"] }
@@ -20,3 +21,9 @@ thiserror = "2.0.14"
 tokio = { version = "1.38.0", features = ["full"] }
 toml = "0.8.14"
 typst-syntax = "0.13.1"
+
+[features]
+test = ["mockall"]
+
+[dev-dependencies]
+typst-preprocess = { path = ".", features = ["test"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 [dependencies]
 async-trait = "0.1.80"
 clap = { version = "4.5.7", features = ["derive", "env"] }
+derive_more = { version = "2.0.1", features = ["debug"] }
 itertools = "0.14.0"
 once_cell = "1.19.0"
 reqwest = "0.12.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,5 @@ typst-syntax = "0.13.1"
 test = ["mockall"]
 
 [dev-dependencies]
+serial_test = "3.2.0"
 typst-preprocess = { path = ".", features = ["test"] }

--- a/justfile
+++ b/justfile
@@ -3,6 +3,7 @@ default:
 	@just --list --unsorted
 
 test:
+    cargo test
     cd tests && just
 
 test-assets:

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,13 +1,9 @@
 //! CLI argument parsing types
 
-use std::io;
-use std::path::{self, Component, Path, PathBuf};
+use std::path::PathBuf;
 
 use clap::Parser;
 use once_cell::sync::Lazy;
-use tokio::fs;
-
-use crate::manifest::{self, PrequeryManifest};
 
 /// Map of preprocessors defined in this crate
 pub static ARGS: Lazy<CliArguments> = Lazy::new(CliArguments::parse);
@@ -26,89 +22,4 @@ pub struct CliArguments {
     /// Path to input Typst file. `prequery-preprocess` will look for a `typst.toml` file in
     /// directories upwards from that file to determine queries.
     pub input: PathBuf,
-}
-
-impl CliArguments {
-    /// Returns the path of the `typst.toml` file that is closest to the input file.
-    pub async fn resolve_typst_toml(&self) -> io::Result<PathBuf> {
-        const TYPST_TOML: &str = "typst.toml";
-
-        let input = path::absolute(&self.input)?;
-        let mut p = input.clone();
-
-        // the input path needs to refer to a file. refer to typst.toml instead
-        p.set_file_name(TYPST_TOML);
-        // repeat as long as the path does not point to an accessible regular file
-        while !fs::metadata(&p).await.is_ok_and(|m| m.is_file()) {
-            // remove the file name
-            let result = p.pop();
-            assert!(
-                result,
-                "the path should have had a final component of `{TYPST_TOML}`"
-            );
-            // go one level up
-            let result = p.pop();
-            if !result {
-                // if there is no level up, not typst.toml was found
-                let input_str = input.to_string_lossy();
-                let msg = format!("no {TYPST_TOML} file found for input file {input_str}");
-                return Err(io::Error::new(io::ErrorKind::NotFound, msg));
-            }
-            // re-add the file name
-            p.push(TYPST_TOML);
-        }
-        Ok(p)
-    }
-
-    /// Reads the `typst.toml` file that is closest to the input file.
-    pub async fn read_typst_toml(&self) -> manifest::Result<PrequeryManifest> {
-        let typst_toml = ARGS
-            .resolve_typst_toml()
-            .await
-            .map_err(manifest::Error::from)?;
-        let config = PrequeryManifest::read(typst_toml).await?;
-        Ok(config)
-    }
-
-    /// returns the root path. This is either the explicitly given root or the directory in which
-    /// the input file is located. If the input file path only consists of a file name, the current
-    /// directory (`"."`) is the root. In general, this function does not return an absolute path.
-    pub fn resolve_root(&self) -> &Path {
-        if let Some(root) = &self.root {
-            // a root was explicitly given
-            root
-        } else if let Some(root) = self.input.parent() {
-            // the root is the directory of the input file
-            root
-        } else {
-            // the root is the directory of the input file, which is the current directory
-            Path::new(".")
-        }
-    }
-
-    /// Resolve the virtual path relative to an actual file system root
-    /// (where the project or package resides).
-    ///
-    /// Returns `None` if the path lexically escapes the root. The path might
-    /// still escape through symlinks.
-    pub fn resolve(&self, path: &Path) -> Option<PathBuf> {
-        let root = self.resolve_root();
-        let root_len = root.as_os_str().len();
-        let mut out = root.to_path_buf();
-        for component in path.components() {
-            match component {
-                Component::Prefix(_) => {}
-                Component::RootDir => {}
-                Component::CurDir => {}
-                Component::ParentDir => {
-                    out.pop();
-                    if out.as_os_str().len() < root_len {
-                        return None;
-                    }
-                }
-                Component::Normal(_) => out.push(component),
-            }
-        }
-        Some(out)
-    }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,10 +3,6 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use once_cell::sync::Lazy;
-
-/// Map of preprocessors defined in this crate
-pub static ARGS: Lazy<CliArguments> = Lazy::new(CliArguments::parse);
 
 /// prequery-preprocess args
 #[derive(Parser, Debug, Clone, PartialEq, Eq)]

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::error::{MultiplePreprocessorExecutionError, Result};
 use crate::utils;
-use crate::world::{DefaultWorld, World};
+use crate::world::{DefaultWorld, World, WorldExt};
 
 /// Entry point; reads the command line arguments, determines the input files and jobs to run, and
 /// then executes the jobs.
@@ -17,7 +17,7 @@ pub async fn main() -> Result<()> {
 pub async fn run(world: impl World) -> Result<()> {
     let world = Arc::new(world);
     let config = world.read_typst_toml().await?;
-    let jobs = config.get_preprocessors(&world)?;
+    let jobs = world.get_preprocessors(config)?;
 
     let jobs = jobs.into_iter().map(|mut job| async move {
         println!("[{}] beginning job...", job.name());

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -2,15 +2,17 @@
 
 use crate::args::ARGS;
 use crate::error::{MultiplePreprocessorExecutionError, Result};
-use crate::preprocessor::preprocessors;
 use crate::utils;
+use crate::world::DefaultWorld;
 
 /// Entry point; reads the command line arguments, determines the input files and jobs to run, and
 /// then executes the jobs.
 #[tokio::main]
 pub async fn main() -> Result<()> {
+    let world = DefaultWorld::new();
+
     let config = ARGS.read_typst_toml().await?;
-    let jobs = config.get_preprocessors(&preprocessors())?;
+    let jobs = config.get_preprocessors(&world)?;
 
     let jobs = jobs.into_iter().map(|mut job| async move {
         println!("[{}] beginning job...", job.name());

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,15 +1,17 @@
 //! Contains the executable's entry point
 
+use std::sync::Arc;
+
 use crate::args::ARGS;
 use crate::error::{MultiplePreprocessorExecutionError, Result};
 use crate::utils;
-use crate::world::DefaultWorld;
+use crate::world::{DefaultWorld, DynWorld};
 
 /// Entry point; reads the command line arguments, determines the input files and jobs to run, and
 /// then executes the jobs.
 #[tokio::main]
 pub async fn main() -> Result<()> {
-    let world = DefaultWorld::new();
+    let world: DynWorld = Arc::new(DefaultWorld::new());
 
     let config = ARGS.read_typst_toml().await?;
     let jobs = config.get_preprocessors(&world)?;

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 
-use crate::args::ARGS;
 use crate::error::{MultiplePreprocessorExecutionError, Result};
 use crate::utils;
 use crate::world::{DefaultWorld, DynWorld};
@@ -13,7 +12,7 @@ use crate::world::{DefaultWorld, DynWorld};
 pub async fn main() -> Result<()> {
     let world: DynWorld = Arc::new(DefaultWorld::new());
 
-    let config = ARGS.read_typst_toml().await?;
+    let config = world.read_typst_toml().await?;
     let jobs = config.get_preprocessors(&world)?;
 
     let jobs = jobs.into_iter().map(|mut job| async move {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -4,13 +4,13 @@ use std::sync::Arc;
 
 use crate::error::{MultiplePreprocessorExecutionError, Result};
 use crate::utils;
-use crate::world::{DefaultWorld, DynWorld};
+use crate::world::{DefaultWorld, World};
 
 /// Entry point; reads the command line arguments, determines the input files and jobs to run, and
 /// then executes the jobs.
 #[tokio::main]
 pub async fn main() -> Result<()> {
-    let world: DynWorld = Arc::new(DefaultWorld::new());
+    let world = Arc::new(DefaultWorld::new());
 
     let config = world.read_typst_toml().await?;
     let jobs = config.get_preprocessors(&world)?;

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -10,8 +10,12 @@ use crate::world::{DefaultWorld, World};
 /// then executes the jobs.
 #[tokio::main]
 pub async fn main() -> Result<()> {
-    let world = Arc::new(DefaultWorld::new());
+    run(DefaultWorld::new()).await
+}
 
+/// Entry point; takes a World and executes preprocessors according to the contained data.
+pub async fn run(world: impl World) -> Result<()> {
+    let world = Arc::new(world);
     let config = world.read_typst_toml().await?;
     let jobs = config.get_preprocessors(&world)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(missing_docs)]
+#![cfg_attr(not(feature = "test"), warn(missing_docs))]
 //! A tool for processing [prequery](https://typst.app/universe/package/prequery) data in Typst documents.
 
 pub mod args;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod preprocessor;
 mod preprocessors;
 pub mod query;
 mod utils;
+mod world;
 
 // re-export the actual preprocessors from the top level
 pub use preprocessors::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,28 @@ pub mod preprocessor;
 mod preprocessors;
 pub mod query;
 mod utils;
-mod world;
+pub mod world;
 
 // re-export the actual preprocessors from the top level
 pub use preprocessors::*;
+
+#[cfg(feature = "test")]
+pub use test_utils::*;
+
+#[cfg(feature = "test")]
+mod test_utils {
+    use std::error::Error;
+    use std::fmt::Display;
+
+    /// Never type, see https://github.com/rust-lang/rust/issues/35121
+    #[derive(Debug)]
+    pub enum Never {}
+
+    impl Display for Never {
+        fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match *self {}
+        }
+    }
+
+    impl Error for Never {}
+}

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::sync::Arc;
 
 use itertools::{Either, Itertools};
 use serde::de::{self, Visitor};
@@ -11,7 +12,7 @@ use typst_syntax::package::PackageManifest;
 
 use crate::error::MultiplePreprocessorConfigError;
 use crate::preprocessor::BoxedPreprocessor;
-use crate::world::DynWorld;
+use crate::world::World;
 
 pub use error::*;
 
@@ -73,10 +74,10 @@ impl PrequeryManifest {
 
     /// Tries to configure all preprocessors in this manifest. Fails if any preprocessors can not be
     /// configured.
-    pub fn get_preprocessors(
+    pub fn get_preprocessors<W: World>(
         self,
-        world: &DynWorld,
-    ) -> Result<Vec<BoxedPreprocessor>, MultiplePreprocessorConfigError> {
+        world: &Arc<W>,
+    ) -> Result<Vec<BoxedPreprocessor<W>>, MultiplePreprocessorConfigError> {
         let (jobs, errors): (Vec<_>, Vec<_>) =
             self.jobs.into_iter().partition_map(|job| {
                 match world.preprocessors().get(world, job) {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -12,7 +12,8 @@ use toml::Table;
 use typst_syntax::package::PackageManifest;
 
 use crate::error::MultiplePreprocessorConfigError;
-use crate::preprocessor::{BoxedPreprocessor, PreprocessorMap};
+use crate::preprocessor::BoxedPreprocessor;
+use crate::world::World;
 
 pub use error::*;
 
@@ -83,12 +84,12 @@ impl PrequeryManifest {
     /// configured.
     pub fn get_preprocessors(
         self,
-        preprocessors: &PreprocessorMap,
+        world: &impl World,
     ) -> Result<Vec<BoxedPreprocessor>, MultiplePreprocessorConfigError> {
         let (jobs, errors): (Vec<_>, Vec<_>) =
             self.jobs
                 .into_iter()
-                .partition_map(|job| match preprocessors.get(job) {
+                .partition_map(|job| match world.preprocessors().get(job) {
                     Ok(value) => Either::Left(value),
                     Err(err) => Either::Right(err),
                 });

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -104,7 +104,7 @@ where
         type Value = Option<Option<String>>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            formatter.write_str("`false` or a string`")
+            formatter.write_str("`false` or a string")
         }
 
         fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -2,12 +2,10 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::path::Path;
 
 use itertools::{Either, Itertools};
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer};
-use tokio::fs;
 use toml::Table;
 use typst_syntax::package::PackageManifest;
 
@@ -70,13 +68,6 @@ impl PrequeryManifest {
             .ok_or(Error::Missing)?
             .try_into::<Self>()
             .map_err(Error::from)?;
-        Ok(config)
-    }
-
-    /// Resolves and reads the given `typst.toml` file.
-    pub async fn read<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let config = fs::read_to_string(path).await?;
-        let config = Self::parse(&config)?;
         Ok(config)
     }
 

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -7,9 +7,11 @@ mod factory;
 pub use error::{ConfigError, ConfigResult, ExecutionError, ExecutionResult, ManifestError};
 pub use factory::{PreprocessorDefinition, PreprocessorFactory, PreprocessorMap};
 
+use crate::world::World;
+
 /// A configured preprocessor that can be executed for its side effect
 #[async_trait]
-pub trait Preprocessor {
+pub trait Preprocessor<W: World> {
     /// this preprocessor's name, which normally comes from [Job::name][crate::manifest::Job::name].
     fn name(&self) -> &str;
 
@@ -18,7 +20,7 @@ pub trait Preprocessor {
 }
 
 /// A dynamically dispatched, boxed preprocessor
-pub type BoxedPreprocessor = Box<dyn Preprocessor + Send>;
+pub type BoxedPreprocessor<W> = Box<dyn Preprocessor<W> + Send>;
 
 mod error {
     use std::borrow::Cow;

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -5,11 +5,14 @@ use async_trait::async_trait;
 mod factory;
 
 pub use error::{ConfigError, ConfigResult, ExecutionError, ExecutionResult, ManifestError};
+#[cfg(feature = "test")]
+pub use factory::MockPreprocessorDefinition;
 pub use factory::{PreprocessorDefinition, PreprocessorFactory, PreprocessorMap};
 
 use crate::world::World;
 
 /// A configured preprocessor that can be executed for its side effect
+#[cfg_attr(feature = "test", mockall::automock)]
 #[async_trait]
 pub trait Preprocessor<W: World> {
     /// this preprocessor's name, which normally comes from [Job::name][crate::manifest::Job::name].

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 mod factory;
 
 pub use error::{ConfigError, ConfigResult, ExecutionError, ExecutionResult, ManifestError};
-pub use factory::{preprocessors, PreprocessorDefinition, PreprocessorFactory, PreprocessorMap};
+pub use factory::{PreprocessorDefinition, PreprocessorFactory, PreprocessorMap};
 
 /// A configured preprocessor that can be executed for its side effect
 #[async_trait]

--- a/src/preprocessor/factory.rs
+++ b/src/preprocessor/factory.rs
@@ -10,6 +10,7 @@ use crate::manifest;
 use crate::world::World;
 
 /// A preprocessor definition that [Preprocessor][super::Preprocessor]s can be created from.
+#[cfg_attr(feature = "test", mockall::automock(type Error = crate::Never;))]
 pub trait PreprocessorDefinition<W: World> {
     /// The specific error type for this preprocessor
     type Error: Error + Send + Sync + 'static;

--- a/src/preprocessor/factory.rs
+++ b/src/preprocessor/factory.rs
@@ -64,7 +64,7 @@ where
 
 /// A map of preprocessor definitions that can be used to run a set of [Jobs][manifest::Job].
 pub struct PreprocessorMap {
-    map: HashMap<Cow<'static, str>, Box<dyn PreprocessorFactory>>,
+    map: HashMap<Cow<'static, str>, Box<dyn PreprocessorFactory + Send + Sync>>,
 }
 
 impl Default for PreprocessorMap {
@@ -84,7 +84,7 @@ impl PreprocessorMap {
     /// Registers a preprocessor definition with its name in the map
     pub fn register<T>(&mut self, preprocessor: T)
     where
-        T: PreprocessorDefinition + 'static,
+        T: PreprocessorDefinition + Send + Sync + 'static,
     {
         self.map.insert(preprocessor.name(), Box::new(preprocessor));
     }

--- a/src/preprocessor/factory.rs
+++ b/src/preprocessor/factory.rs
@@ -9,7 +9,6 @@ use super::{BoxedPreprocessor, ConfigError, ConfigResult, ManifestError};
 use crate::manifest;
 use crate::world::World;
 
-#[allow(rustdoc::private_intra_doc_links)]
 /// A preprocessor definition that [Preprocessor][super::Preprocessor]s can be created from.
 pub trait PreprocessorDefinition<W: World> {
     /// The specific error type for this preprocessor

--- a/src/preprocessor/factory.rs
+++ b/src/preprocessor/factory.rs
@@ -3,14 +3,15 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::error::Error;
+use std::sync::Arc;
 
 use super::{BoxedPreprocessor, ConfigError, ConfigResult, ManifestError};
 use crate::manifest;
-use crate::world::DynWorld;
+use crate::world::World;
 
 #[allow(rustdoc::private_intra_doc_links)]
 /// A preprocessor definition that [Preprocessor][super::Preprocessor]s can be created from.
-pub trait PreprocessorDefinition {
+pub trait PreprocessorDefinition<W: World> {
     /// The specific error type for this preprocessor
     type Error: Error + Send + Sync + 'static;
 
@@ -20,16 +21,16 @@ pub trait PreprocessorDefinition {
     /// Creates the preprocessor; implementation part.
     fn configure(
         &self,
-        world: &DynWorld,
+        world: &Arc<W>,
         name: String,
         manifest: toml::Table,
         query: manifest::Query,
-    ) -> Result<BoxedPreprocessor, Self::Error>;
+    ) -> Result<BoxedPreprocessor<W>, Self::Error>;
 }
 
 /// A dyn-safe version of [PreprocessorDefinition]. This trait has a blanket implementation and does
 /// not usually need to be implemented manually.
-pub trait PreprocessorFactory {
+pub trait PreprocessorFactory<W: World> {
     /// The identifier of the preprocessor, referenced by the [Job::kind][manifest::Job::kind] field
     fn name(&self) -> Cow<'static, str>;
 
@@ -37,16 +38,16 @@ pub trait PreprocessorFactory {
     /// yet.
     fn configure(
         &self,
-        world: &DynWorld,
+        world: &Arc<W>,
         name: String,
         manifest: toml::Table,
         query: manifest::Query,
-    ) -> ConfigResult<BoxedPreprocessor>;
+    ) -> ConfigResult<BoxedPreprocessor<W>>;
 }
 
-impl<T> PreprocessorFactory for T
+impl<T, W: World> PreprocessorFactory<W> for T
 where
-    T: PreprocessorDefinition,
+    T: PreprocessorDefinition<W>,
 {
     fn name(&self) -> Cow<'static, str> {
         self.name()
@@ -54,11 +55,11 @@ where
 
     fn configure(
         &self,
-        world: &DynWorld,
+        world: &Arc<W>,
         name: String,
         manifest: toml::Table,
         query: manifest::Query,
-    ) -> ConfigResult<BoxedPreprocessor> {
+    ) -> ConfigResult<BoxedPreprocessor<W>> {
         let preprocessor = self
             .configure(world, name, manifest, query)
             .map_err(|error| ManifestError::new(self.name(), error))?;
@@ -67,17 +68,17 @@ where
 }
 
 /// A map of preprocessor definitions that can be used to run a set of [Jobs][manifest::Job].
-pub struct PreprocessorMap {
-    map: HashMap<Cow<'static, str>, Box<dyn PreprocessorFactory + Send + Sync>>,
+pub struct PreprocessorMap<W: World + ?Sized> {
+    map: HashMap<Cow<'static, str>, Box<dyn PreprocessorFactory<W> + Send + Sync>>,
 }
 
-impl Default for PreprocessorMap {
+impl<W: World> Default for PreprocessorMap<W> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl PreprocessorMap {
+impl<W: World> PreprocessorMap<W> {
     /// Creates an empty preprocessor maps
     pub fn new() -> Self {
         Self {
@@ -88,7 +89,7 @@ impl PreprocessorMap {
     /// Registers a preprocessor definition with its name in the map
     pub fn register<T>(&mut self, preprocessor: T)
     where
-        T: PreprocessorDefinition + Send + Sync + 'static,
+        T: PreprocessorDefinition<W> + Send + Sync + 'static,
     {
         self.map.insert(preprocessor.name(), Box::new(preprocessor));
     }
@@ -98,9 +99,9 @@ impl PreprocessorMap {
     /// recognized, or some part of the manifest was not valid for that kind.
     pub fn get(
         &self,
-        world: &DynWorld,
+        world: &Arc<W>,
         job: manifest::Job,
-    ) -> Result<BoxedPreprocessor, (String, ConfigError)> {
+    ) -> Result<BoxedPreprocessor<W>, (String, ConfigError)> {
         let manifest::Job {
             name,
             kind,

--- a/src/preprocessor/factory.rs
+++ b/src/preprocessor/factory.rs
@@ -109,10 +109,3 @@ impl PreprocessorMap {
         inner().map_err(|error| (name, error))
     }
 }
-
-/// Map of preprocessors defined in this crate
-pub fn preprocessors() -> PreprocessorMap {
-    let mut map = PreprocessorMap::new();
-    map.register(crate::web_resource::WebResourceFactory);
-    map
-}

--- a/src/preprocessors/web_resource.rs
+++ b/src/preprocessors/web_resource.rs
@@ -111,13 +111,7 @@ impl<W: World> WebResource<W> {
         if let Some(location) = self.manifest.resolve_index_path(self.world.as_ref()).await {
             // an index is in use
             let location = location?;
-            let index = if fs::try_exists(&location).await.unwrap_or(false) {
-                // read the existing index
-                Index::read(location).await?
-            } else {
-                // generate an empty index
-                Index::new(location)
-            };
+            let index = self.world.read_index(location).await?;
 
             self.index = Some(Mutex::new(index));
         } else {
@@ -211,7 +205,7 @@ impl<W: World> WebResource<W> {
 
         if let Some(index) = &self.index {
             let index = index.lock().await;
-            index.write().await?;
+            self.world.write_index(&index).await?;
         }
 
         if !errors.is_empty() {

--- a/src/preprocessors/web_resource.rs
+++ b/src/preprocessors/web_resource.rs
@@ -110,11 +110,9 @@ impl<W: World> WebResource<W> {
     }
 
     async fn populate_index(&mut self) -> Result<(), IndexError> {
-        if let Some(location) = self.manifest.resolve_index_path(self.world.as_ref()).await {
+        if let Some(path) = self.manifest.index.as_ref() {
             // an index is in use
-            let location = location?;
-            let index = self.world.read_index(location).await?;
-
+            let index = self.world.read_index(path).await?;
             self.index = Some(Mutex::new(index));
         } else {
             // no index is in use

--- a/src/preprocessors/web_resource.rs
+++ b/src/preprocessors/web_resource.rs
@@ -14,7 +14,10 @@ use crate::world::WorldExt as _;
 
 mod error;
 mod factory;
+#[cfg(not(feature = "test"))]
 mod index;
+#[cfg(feature = "test")]
+pub mod index;
 mod manifest;
 mod query_data;
 mod world;
@@ -26,8 +29,6 @@ use world::World;
 
 pub use error::*;
 pub use factory::WebResourceFactory;
-#[cfg(feature = "test")]
-pub use index::Index;
 #[cfg(feature = "test")]
 pub use world::{MockWorld, __mock_MockWorld_World::__new::Context as MockWorld_NewContext};
 

--- a/src/preprocessors/web_resource.rs
+++ b/src/preprocessors/web_resource.rs
@@ -123,7 +123,7 @@ impl<W: World> WebResource<W> {
     }
 
     async fn query(&self) -> query::Result<QueryData> {
-        let data = self.query.execute(self.world.main().as_ref()).await?;
+        let data = self.world.main().query(&self.query).await?;
         Ok(data)
     }
 

--- a/src/preprocessors/web_resource.rs
+++ b/src/preprocessors/web_resource.rs
@@ -10,7 +10,7 @@ use tokio::sync::Mutex;
 use crate::preprocessor::{self, Preprocessor};
 use crate::query::{self, Query};
 use crate::utils;
-use crate::world::World as _;
+use crate::world::WorldExt as _;
 
 mod error;
 mod factory;

--- a/src/preprocessors/web_resource.rs
+++ b/src/preprocessors/web_resource.rs
@@ -127,7 +127,7 @@ impl WebResource {
     }
 
     async fn query(&self) -> query::Result<QueryData> {
-        let data = self.query.query().await?;
+        let data = self.query.execute(self.world.as_ref()).await?;
         Ok(data)
     }
 

--- a/src/preprocessors/web_resource.rs
+++ b/src/preprocessors/web_resource.rs
@@ -27,7 +27,7 @@ use world::World;
 pub use error::*;
 pub use factory::WebResourceFactory;
 #[cfg(feature = "test")]
-pub use world::MockWorld;
+pub use world::{MockWorld, __mock_MockWorld_World::__new::Context as MockWorld_NewContext};
 
 /// The `web-resource` preprocessor
 #[derive(Debug)]

--- a/src/preprocessors/web_resource.rs
+++ b/src/preprocessors/web_resource.rs
@@ -27,6 +27,8 @@ use world::World;
 pub use error::*;
 pub use factory::WebResourceFactory;
 #[cfg(feature = "test")]
+pub use index::Index;
+#[cfg(feature = "test")]
 pub use world::{MockWorld, __mock_MockWorld_World::__new::Context as MockWorld_NewContext};
 
 /// The `web-resource` preprocessor

--- a/src/preprocessors/web_resource.rs
+++ b/src/preprocessors/web_resource.rs
@@ -26,6 +26,8 @@ use world::World;
 
 pub use error::*;
 pub use factory::WebResourceFactory;
+#[cfg(feature = "test")]
+pub use world::MockWorld;
 
 /// The `web-resource` preprocessor
 #[derive(Debug)]

--- a/src/preprocessors/web_resource/factory.rs
+++ b/src/preprocessors/web_resource/factory.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use crate::manifest;
 use crate::preprocessor::{BoxedPreprocessor, PreprocessorDefinition};
 use crate::query::Query;
+use crate::world::DynWorld;
 
 use super::{Manifest, ManifestError, ManifestResult, QueryConfigError, WebResource};
 
@@ -41,6 +42,7 @@ impl PreprocessorDefinition for WebResourceFactory {
 
     fn configure(
         &self,
+        _world: &DynWorld,
         name: String,
         config: toml::Table,
         query: manifest::Query,

--- a/src/preprocessors/web_resource/factory.rs
+++ b/src/preprocessors/web_resource/factory.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use crate::manifest;
 use crate::preprocessor::{BoxedPreprocessor, PreprocessorDefinition};
 use crate::query::Query;
-use crate::world::DynWorld;
+use crate::world::World;
 
 use super::{Manifest, ManifestError, ManifestResult, QueryConfigError, WebResource};
 
@@ -33,7 +33,7 @@ impl WebResourceFactory {
     }
 }
 
-impl PreprocessorDefinition for WebResourceFactory {
+impl<W: World> PreprocessorDefinition<W> for WebResourceFactory {
     type Error = ManifestError;
 
     fn name(&self) -> Cow<'static, str> {
@@ -42,11 +42,11 @@ impl PreprocessorDefinition for WebResourceFactory {
 
     fn configure(
         &self,
-        world: &DynWorld,
+        world: &Arc<W>,
         name: String,
         config: toml::Table,
         query: manifest::Query,
-    ) -> ManifestResult<BoxedPreprocessor> {
+    ) -> ManifestResult<BoxedPreprocessor<W>> {
         let config = Self::parse_config(config)?;
         // index begins as None and is asynchronously populated later
         let index = None;

--- a/src/preprocessors/web_resource/factory.rs
+++ b/src/preprocessors/web_resource/factory.rs
@@ -42,7 +42,7 @@ impl PreprocessorDefinition for WebResourceFactory {
 
     fn configure(
         &self,
-        _world: &DynWorld,
+        world: &DynWorld,
         name: String,
         config: toml::Table,
         query: manifest::Query,
@@ -51,7 +51,7 @@ impl PreprocessorDefinition for WebResourceFactory {
         // index begins as None and is asynchronously populated later
         let index = None;
         let query = Self::build_query(query)?;
-        let instance = WebResource::new(name, config, index, query);
+        let instance = WebResource::new(world.clone(), name, config, index, query);
         Ok(Box::new(Arc::new(instance)))
     }
 }

--- a/src/preprocessors/web_resource/manifest.rs
+++ b/src/preprocessors/web_resource/manifest.rs
@@ -5,7 +5,9 @@ use std::path::{Path, PathBuf};
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer};
 
-use crate::world::World;
+use crate::world::World as _;
+
+use super::world::World;
 
 /// Auxilliary configuration for the preprocessor
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -30,7 +32,7 @@ pub struct Manifest {
 impl Manifest {
     pub async fn resolve_index_path(&self, world: &impl World) -> Option<io::Result<PathBuf>> {
         async fn inner<P: AsRef<Path>>(index: P, world: &impl World) -> io::Result<PathBuf> {
-            let mut path = world.resolve_typst_toml().await?;
+            let mut path = world.main().resolve_typst_toml().await?;
             let result = path.pop();
             assert!(
                 result,

--- a/src/preprocessors/web_resource/manifest.rs
+++ b/src/preprocessors/web_resource/manifest.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer};
 
-use crate::args::ARGS;
+use crate::world::DynWorld;
 
 /// Auxilliary configuration for the preprocessor
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -28,9 +28,9 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    pub async fn resolve_index_path(&self) -> Option<io::Result<PathBuf>> {
-        async fn inner<P: AsRef<Path>>(index: P) -> io::Result<PathBuf> {
-            let mut path = ARGS.resolve_typst_toml().await?;
+    pub async fn resolve_index_path(&self, world: &DynWorld) -> Option<io::Result<PathBuf>> {
+        async fn inner<P: AsRef<Path>>(index: P, world: &DynWorld) -> io::Result<PathBuf> {
+            let mut path = world.resolve_typst_toml().await?;
             let result = path.pop();
             assert!(
                 result,
@@ -41,7 +41,7 @@ impl Manifest {
         }
 
         if let Some(index) = &self.index {
-            Some(inner(index).await)
+            Some(inner(index, world).await)
         } else {
             None
         }

--- a/src/preprocessors/web_resource/manifest.rs
+++ b/src/preprocessors/web_resource/manifest.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer};
 
-use crate::world::DynWorld;
+use crate::world::World;
 
 /// Auxilliary configuration for the preprocessor
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -28,8 +28,8 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    pub async fn resolve_index_path(&self, world: &DynWorld) -> Option<io::Result<PathBuf>> {
-        async fn inner<P: AsRef<Path>>(index: P, world: &DynWorld) -> io::Result<PathBuf> {
+    pub async fn resolve_index_path(&self, world: &impl World) -> Option<io::Result<PathBuf>> {
+        async fn inner<P: AsRef<Path>>(index: P, world: &impl World) -> io::Result<PathBuf> {
             let mut path = world.resolve_typst_toml().await?;
             let result = path.pop();
             assert!(

--- a/src/preprocessors/web_resource/manifest.rs
+++ b/src/preprocessors/web_resource/manifest.rs
@@ -1,13 +1,8 @@
 use std::fmt;
-use std::io;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer};
-
-use crate::world::World as _;
-
-use super::world::World;
 
 /// Auxilliary configuration for the preprocessor
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -27,27 +22,6 @@ pub struct Manifest {
     /// to be enabled.
     #[serde(default)]
     pub evict: bool,
-}
-
-impl Manifest {
-    pub async fn resolve_index_path(&self, world: &impl World) -> Option<io::Result<PathBuf>> {
-        async fn inner<P: AsRef<Path>>(index: P, world: &impl World) -> io::Result<PathBuf> {
-            let mut path = world.main().resolve_typst_toml().await?;
-            let result = path.pop();
-            assert!(
-                result,
-                "the path should have had a final filename component"
-            );
-            path.push(&index);
-            Ok(path)
-        }
-
-        if let Some(index) = &self.index {
-            Some(inner(index, world).await)
-        } else {
-            None
-        }
-    }
 }
 
 /// Deserializes the `index` config: if given, must be either a boolean or string.

--- a/src/preprocessors/web_resource/world.rs
+++ b/src/preprocessors/web_resource/world.rs
@@ -10,6 +10,7 @@ use super::{DownloadError, IndexError};
 
 /// The context for executing a WebResource job. Defines how downloading and saving files work, and
 /// thus allows mocking.
+#[cfg_attr(feature = "test", mockall::automock(type MainWorld = crate::world::MockWorld;))]
 #[async_trait]
 pub trait World: Send + Sync + 'static {
     type MainWorld: crate::world::World;

--- a/src/preprocessors/web_resource/world.rs
+++ b/src/preprocessors/web_resource/world.rs
@@ -13,12 +13,16 @@ use super::IndexError;
 pub trait World: Send + Sync + 'static {
     type MainWorld: crate::world::World;
 
+    /// Creates a new web resource world based on the given main world.
     fn new(main: Arc<Self::MainWorld>) -> Self;
 
+    /// Accesses the main world.
     fn main(&self) -> &Arc<Self::MainWorld>;
 
+    /// Reads the web resource index at the specified location.
     async fn read_index(&self, location: PathBuf) -> Result<Index, IndexError>;
 
+    /// Writes the web resource index to its location.
     async fn write_index(&self, index: &Index) -> Result<(), IndexError>;
 }
 

--- a/src/preprocessors/web_resource/world.rs
+++ b/src/preprocessors/web_resource/world.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+/// The context for executing a WebResource job. Defines how downloading and saving files work, and
+/// thus allows mocking.
+pub trait World: Send + Sync + 'static {
+    type MainWorld: crate::world::World;
+
+    fn new(main: Arc<Self::MainWorld>) -> Self;
+
+    fn main(&self) -> &Arc<Self::MainWorld>;
+}
+
+/// The default context, accessing the real web and filesystem.
+#[derive(Clone)]
+pub struct DefaultWorld {
+    main: Arc<crate::world::DefaultWorld>,
+}
+
+impl World for DefaultWorld {
+    type MainWorld = crate::world::DefaultWorld;
+
+    fn new(main: Arc<Self::MainWorld>) -> Self {
+        Self { main }
+    }
+
+    fn main(&self) -> &Arc<Self::MainWorld> {
+        &self.main
+    }
+}

--- a/src/query.rs
+++ b/src/query.rs
@@ -2,10 +2,7 @@
 
 use std::collections::HashMap;
 
-use serde::Deserialize;
-
 use crate::manifest;
-use crate::world::World;
 
 pub use error::*;
 
@@ -29,18 +26,6 @@ impl Query {
     /// Creates a query builder
     pub fn builder() -> QueryBuilder {
         QueryBuilder::default()
-    }
-
-    /// Executes the query. This builds the necessary command line, runs the command, and returns
-    /// the result parsed into the desired type from JSON.
-    pub async fn execute<T, W>(&self, world: &W) -> Result<T>
-    where
-        T: for<'a> Deserialize<'a>,
-        W: World + ?Sized,
-    {
-        let output = world.query(self).await?;
-        let value = serde_json::from_slice(&output)?;
-        Ok(value)
     }
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,14 +1,11 @@
 //! Executing `typst query` commands
 
 use std::collections::HashMap;
-use std::fmt::Write;
-use std::process::Stdio;
 
 use serde::Deserialize;
-use tokio::process::Command;
 
-use crate::args::ARGS;
 use crate::manifest;
+use crate::world::World;
 
 pub use error::*;
 
@@ -34,47 +31,15 @@ impl Query {
         QueryBuilder::default()
     }
 
-    /// Builds the `typst query` command line for executing this command.
-    pub fn command(&self) -> Command {
-        let mut cmd = Command::new(&ARGS.typst);
-        cmd.arg("query");
-        if let Some(root) = &ARGS.root {
-            cmd.arg("--root").arg(root);
-        }
-        if let Some(field) = &self.field {
-            cmd.arg("--field").arg(field);
-        }
-        if self.one {
-            cmd.arg("--one");
-        }
-        let mut input = String::new();
-        for (key, value) in &self.inputs {
-            input.clear();
-            write!(&mut input, "{key}={value}").expect("writing to a string failed");
-            cmd.arg("--input").arg(&input);
-        }
-        cmd.arg("--input").arg("prequery-fallback=true");
-        cmd.arg(&ARGS.input).arg(&self.selector);
-
-        cmd
-    }
-
     /// Executes the query. This builds the necessary command line, runs the command, and returns
     /// the result parsed into the desired type from JSON.
-    pub async fn query<T>(&self) -> Result<T>
+    pub async fn execute<T, W>(&self, world: &W) -> Result<T>
     where
         T: for<'a> Deserialize<'a>,
+        W: World + ?Sized,
     {
-        let mut command = self.command();
-        command.stderr(Stdio::inherit());
-        let output = command.output().await?;
-        if !output.status.success() {
-            let command = Box::new(command);
-            let status = output.status;
-            Err(Error::Failure { command, status })?;
-        }
-
-        let value = serde_json::from_slice(&output.stdout)?;
+        let output = world.query(self).await?;
+        let value = serde_json::from_slice(&output)?;
         Ok(value)
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,7 +1,7 @@
 use crate::preprocessor::PreprocessorMap;
 
 /// The context for executing preprocessors.
-pub trait World {
+pub trait World: Send + Sync {
     /// Map of preprocessors existing in this World
     fn preprocessors(&self) -> &PreprocessorMap;
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::preprocessor::PreprocessorMap;
 
 /// The context for executing preprocessors.
@@ -5,6 +7,8 @@ pub trait World: Send + Sync {
     /// Map of preprocessors existing in this World
     fn preprocessors(&self) -> &PreprocessorMap;
 }
+
+pub type DynWorld = Arc<dyn World>;
 
 /// The default context, accessing the real web, filesystem, etc.
 pub struct DefaultWorld {

--- a/src/world.rs
+++ b/src/world.rs
@@ -27,9 +27,6 @@ pub trait World: Send + Sync + 'static {
     /// The arguments given to the invocation
     fn arguments(&self) -> &CliArguments;
 
-    /// Returns the path of the `typst.toml` file that is closest to the input file.
-    async fn resolve_typst_toml(&self) -> io::Result<PathBuf>;
-
     /// Reads the `typst.toml` file that is closest to the input file.
     async fn read_typst_toml(&self) -> manifest::Result<PrequeryManifest>;
 
@@ -109,19 +106,9 @@ impl DefaultWorld {
             arguments,
         }
     }
-}
 
-#[async_trait]
-impl World for DefaultWorld {
-    fn preprocessors(&self) -> &PreprocessorMap<Self> {
-        &self.preprocessors
-    }
-
-    fn arguments(&self) -> &CliArguments {
-        &self.arguments
-    }
-
-    async fn resolve_typst_toml(&self) -> io::Result<PathBuf> {
+    /// Returns the path of the `typst.toml` file that is closest to the input file.
+    pub async fn resolve_typst_toml(&self) -> io::Result<PathBuf> {
         const TYPST_TOML: &str = "typst.toml";
 
         let input = path::absolute(&self.arguments().input)?;
@@ -149,6 +136,17 @@ impl World for DefaultWorld {
             p.push(TYPST_TOML);
         }
         Ok(p)
+    }
+}
+
+#[async_trait]
+impl World for DefaultWorld {
+    fn preprocessors(&self) -> &PreprocessorMap<Self> {
+        &self.preprocessors
+    }
+
+    fn arguments(&self) -> &CliArguments {
+        &self.arguments
     }
 
     async fn read_typst_toml(&self) -> manifest::Result<PrequeryManifest> {

--- a/src/world.rs
+++ b/src/world.rs
@@ -63,8 +63,8 @@ impl Default for DefaultWorld {
 impl DefaultWorld {
     /// Creates the default world.
     pub fn new() -> Self {
-        let mut preprocessors = PreprocessorMap::new();
-        preprocessors.register(crate::web_resource::WebResourceFactory);
+        let mut preprocessors = PreprocessorMap::default();
+        preprocessors.register(crate::web_resource::WebResourceFactory::default());
         Self { preprocessors }
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -112,7 +112,8 @@ impl World for DefaultWorld {
             .resolve_typst_toml()
             .await
             .map_err(manifest::Error::from)?;
-        let config = PrequeryManifest::read(typst_toml).await?;
+        let config = fs::read_to_string(typst_toml).await?;
+        let config = PrequeryManifest::parse(&config)?;
         Ok(config)
     }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,11 +1,40 @@
+use std::io;
+use std::path::{self, Component, Path, PathBuf};
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use tokio::fs;
+
+use crate::args::{CliArguments, ARGS};
+use crate::manifest::{self, PrequeryManifest};
 use crate::preprocessor::PreprocessorMap;
 
 /// The context for executing preprocessors.
+#[async_trait]
 pub trait World: Send + Sync {
     /// Map of preprocessors existing in this World
     fn preprocessors(&self) -> &PreprocessorMap;
+
+    /// The arguments given to the invocation
+    fn arguments(&self) -> &CliArguments;
+
+    /// Returns the path of the `typst.toml` file that is closest to the input file.
+    async fn resolve_typst_toml(&self) -> io::Result<PathBuf>;
+
+    /// Reads the `typst.toml` file that is closest to the input file.
+    async fn read_typst_toml(&self) -> manifest::Result<PrequeryManifest>;
+
+    /// returns the root path. This is either the explicitly given root or the directory in which
+    /// the input file is located. If the input file path only consists of a file name, the current
+    /// directory (`"."`) is the root. In general, this function does not return an absolute path.
+    fn resolve_root(&self) -> &Path;
+
+    /// Resolve the virtual path relative to an actual file system root
+    /// (where the project or package resides).
+    ///
+    /// Returns `None` if the path lexically escapes the root. The path might
+    /// still escape through symlinks.
+    fn resolve(&self, path: &Path) -> Option<PathBuf>;
 }
 
 pub type DynWorld = Arc<dyn World>;
@@ -30,8 +59,86 @@ impl DefaultWorld {
     }
 }
 
+#[async_trait]
 impl World for DefaultWorld {
     fn preprocessors(&self) -> &PreprocessorMap {
         &self.preprocessors
+    }
+
+    fn arguments(&self) -> &CliArguments {
+        &ARGS
+    }
+
+    async fn resolve_typst_toml(&self) -> io::Result<PathBuf> {
+        const TYPST_TOML: &str = "typst.toml";
+
+        let input = path::absolute(&self.arguments().input)?;
+        let mut p = input.clone();
+
+        // the input path needs to refer to a file. refer to typst.toml instead
+        p.set_file_name(TYPST_TOML);
+        // repeat as long as the path does not point to an accessible regular file
+        while !fs::metadata(&p).await.is_ok_and(|m| m.is_file()) {
+            // remove the file name
+            let result = p.pop();
+            assert!(
+                result,
+                "the path should have had a final component of `{TYPST_TOML}`"
+            );
+            // go one level up
+            let result = p.pop();
+            if !result {
+                // if there is no level up, not typst.toml was found
+                let input_str = input.to_string_lossy();
+                let msg = format!("no {TYPST_TOML} file found for input file {input_str}");
+                return Err(io::Error::new(io::ErrorKind::NotFound, msg));
+            }
+            // re-add the file name
+            p.push(TYPST_TOML);
+        }
+        Ok(p)
+    }
+
+    async fn read_typst_toml(&self) -> manifest::Result<PrequeryManifest> {
+        let typst_toml = self
+            .resolve_typst_toml()
+            .await
+            .map_err(manifest::Error::from)?;
+        let config = PrequeryManifest::read(typst_toml).await?;
+        Ok(config)
+    }
+
+    fn resolve_root(&self) -> &Path {
+        if let Some(root) = &self.arguments().root {
+            // a root was explicitly given
+            root
+        } else if let Some(root) = self.arguments().input.parent() {
+            // the root is the directory of the input file
+            root
+        } else {
+            // the root is the directory of the input file, which is the current directory
+            Path::new(".")
+        }
+    }
+
+    fn resolve(&self, path: &Path) -> Option<PathBuf> {
+        let root = self.resolve_root();
+        let root_len = root.as_os_str().len();
+        let mut out = root.to_path_buf();
+        for component in path.components() {
+            match component {
+                Component::Prefix(_) => {}
+                Component::RootDir => {}
+                Component::CurDir => {}
+                Component::ParentDir => {
+                    out.pop();
+                    if out.as_os_str().len() < root_len {
+                        return None;
+                    }
+                }
+                Component::Normal(_) => out.push(component),
+            }
+        }
+        Some(out)
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,0 +1,33 @@
+use crate::preprocessor::PreprocessorMap;
+
+/// The context for executing preprocessors.
+pub trait World {
+    /// Map of preprocessors existing in this World
+    fn preprocessors(&self) -> &PreprocessorMap;
+}
+
+/// The default context, accessing the real web, filesystem, etc.
+pub struct DefaultWorld {
+    preprocessors: PreprocessorMap,
+}
+
+impl Default for DefaultWorld {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DefaultWorld {
+    /// Creates the default world.
+    pub fn new() -> Self {
+        let mut preprocessors = PreprocessorMap::new();
+        preprocessors.register(crate::web_resource::WebResourceFactory);
+        Self { preprocessors }
+    }
+}
+
+impl World for DefaultWorld {
+    fn preprocessors(&self) -> &PreprocessorMap {
+        &self.preprocessors
+    }
+}

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,3 +1,7 @@
+//! Abstracts an execution environment preprocessors can run in.
+//! The world mediates access to the file system, the network, and more high-level resources
+//! such as the project manifest
+
 use std::fmt::Write;
 use std::io;
 use std::path::{self, Component, Path, PathBuf};
@@ -13,6 +17,7 @@ use crate::preprocessor::PreprocessorMap;
 use crate::query::{self, Query};
 
 /// The context for executing preprocessors.
+#[cfg_attr(feature = "test", mockall::automock)]
 #[async_trait]
 pub trait World: Send + Sync + 'static {
     /// Map of preprocessors existing in this World

--- a/src/world.rs
+++ b/src/world.rs
@@ -2,7 +2,6 @@ use std::fmt::Write;
 use std::io;
 use std::path::{self, Component, Path, PathBuf};
 use std::process::Stdio;
-use std::sync::Arc;
 
 use async_trait::async_trait;
 use tokio::fs;
@@ -15,9 +14,9 @@ use crate::query::{self, Query};
 
 /// The context for executing preprocessors.
 #[async_trait]
-pub trait World: Send + Sync {
+pub trait World: Send + Sync + 'static {
     /// Map of preprocessors existing in this World
-    fn preprocessors(&self) -> &PreprocessorMap;
+    fn preprocessors(&self) -> &PreprocessorMap<Self>;
 
     /// The arguments given to the invocation
     fn arguments(&self) -> &CliArguments;
@@ -45,11 +44,9 @@ pub trait World: Send + Sync {
     async fn query(&self, query: &Query) -> query::Result<Vec<u8>>;
 }
 
-pub type DynWorld = Arc<dyn World>;
-
 /// The default context, accessing the real web, filesystem, etc.
 pub struct DefaultWorld {
-    preprocessors: PreprocessorMap,
+    preprocessors: PreprocessorMap<Self>,
 }
 
 impl Default for DefaultWorld {
@@ -69,7 +66,7 @@ impl DefaultWorld {
 
 #[async_trait]
 impl World for DefaultWorld {
-    fn preprocessors(&self) -> &PreprocessorMap {
+    fn preprocessors(&self) -> &PreprocessorMap<Self> {
         &self.preprocessors
     }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -8,10 +8,11 @@ use std::path::{self, Component, Path, PathBuf};
 use std::process::Stdio;
 
 use async_trait::async_trait;
+use clap::Parser;
 use tokio::fs;
 use tokio::process::Command;
 
-use crate::args::{CliArguments, ARGS};
+use crate::args::CliArguments;
 use crate::manifest::{self, PrequeryManifest};
 use crate::preprocessor::PreprocessorMap;
 use crate::query::{self, Query};
@@ -88,6 +89,7 @@ impl<T: World> WorldExt for T {}
 /// The default context, accessing the real web, filesystem, etc.
 pub struct DefaultWorld {
     preprocessors: PreprocessorMap<Self>,
+    arguments: CliArguments,
 }
 
 impl Default for DefaultWorld {
@@ -101,7 +103,11 @@ impl DefaultWorld {
     pub fn new() -> Self {
         let mut preprocessors = PreprocessorMap::default();
         preprocessors.register(crate::web_resource::WebResourceFactory::default());
-        Self { preprocessors }
+        let arguments = CliArguments::parse();
+        Self {
+            preprocessors,
+            arguments,
+        }
     }
 }
 
@@ -112,7 +118,7 @@ impl World for DefaultWorld {
     }
 
     fn arguments(&self) -> &CliArguments {
-        &ARGS
+        &self.arguments
     }
 
     async fn resolve_typst_toml(&self) -> io::Result<PathBuf> {

--- a/tests/dummy_world_test.rs
+++ b/tests/dummy_world_test.rs
@@ -43,7 +43,7 @@ async fn run_dummy_preprocessor() -> Result<()> {
     });
     world
         .expect_arguments()
-        .return_const(CliArguments::parse_from(&["typst-preprocess", "input.typ"]));
+        .return_const(CliArguments::parse_from(["typst-preprocess", "input.typ"]));
     world.expect_read_typst_toml().returning(|| {
         PrequeryManifest::parse(
             r#"

--- a/tests/dummy_world_test.rs
+++ b/tests/dummy_world_test.rs
@@ -1,0 +1,64 @@
+use clap::Parser;
+
+use mockall::predicate::{always, eq};
+use typst_preprocess::args::CliArguments;
+use typst_preprocess::entry::run;
+use typst_preprocess::error::Result;
+use typst_preprocess::manifest::PrequeryManifest;
+use typst_preprocess::preprocessor::{
+    MockPreprocessor, MockPreprocessorDefinition, PreprocessorMap,
+};
+use typst_preprocess::world::MockWorld;
+
+#[tokio::test]
+async fn run_dummy_preprocessor() -> Result<()> {
+    // dummy preprocessor that is used by the configuration
+    let mut dummy = MockPreprocessorDefinition::new();
+    dummy.expect_name().return_const("dummy");
+    dummy
+        .expect_configure()
+        .once()
+        .with(always(), eq("test".to_string()), always(), always())
+        .returning(|_world, name, _manifest, _query| {
+            // when run, the preprocessor does nothing
+            let mut preprocessor = MockPreprocessor::new();
+            preprocessor.expect_name().return_const(name);
+            preprocessor.expect_run().once().returning(|| Ok(()));
+            Ok(Box::new(preprocessor))
+        });
+
+    // dummy preprocessor that is not used by the configuration
+    let mut dummy2 = MockPreprocessorDefinition::new();
+    dummy2.expect_name().return_const("dummy2");
+    // must not be used to configure an instance
+    dummy2.expect_configure().never();
+
+    // mock world that contains the two preprocessors and basic setup
+    let mut world = MockWorld::new();
+    world.expect_preprocessors().return_const({
+        let mut preprocessors = PreprocessorMap::new();
+        preprocessors.register(dummy);
+        preprocessors.register(dummy2);
+        preprocessors
+    });
+    world
+        .expect_arguments()
+        .return_const(CliArguments::parse_from(&["typst-preprocess", "input.typ"]));
+    world.expect_read_typst_toml().returning(|| {
+        PrequeryManifest::parse(
+            r#"
+            [package]
+            name = "test"
+            version = "0.0.1"
+            entrypoint = "main.typ"
+
+            [[tool.prequery.jobs]]
+            name = "test"
+            kind = "dummy"
+            "#,
+        )
+    });
+
+    // run the world
+    run(world).await
+}

--- a/tests/web_resource_test.rs
+++ b/tests/web_resource_test.rs
@@ -45,9 +45,6 @@ impl WebResourceTest {
             .expect_arguments()
             .return_const(CliArguments::parse_from(args));
         world
-            .expect_resolve_typst_toml()
-            .returning(|| Ok(PathBuf::from("typst.toml")));
-        world
             .expect_read_typst_toml()
             .returning(|| PrequeryManifest::parse(manifest));
 
@@ -132,7 +129,7 @@ async fn run_web_resource_no_resources_with_index() -> Result<()> {
                 .expect_read_index()
                 .once()
                 .with(eq(PathBuf::from("web-resource-index.toml")))
-                .returning(|location| Ok(Index::new(location)));
+                .returning(|location| Ok(Index::new(location.to_path_buf())));
             world
                 .expect_write_index()
                 .once()
@@ -317,7 +314,7 @@ async fn run_web_resource_with_index_missing() -> Result<()> {
                 .expect_read_index()
                 .once()
                 .with(eq(PathBuf::from("web-resource-index.toml")))
-                .returning(|location| Ok(Index::new(location)));
+                .returning(|location| Ok(Index::new(location.to_path_buf())));
             world
                 .expect_write_index()
                 .once()
@@ -382,7 +379,7 @@ async fn run_web_resource_with_index_existing() -> Result<()> {
                 .once()
                 .with(eq(PathBuf::from("web-resource-index.toml")))
                 .returning(|location| {
-                    let mut index = Index::new(location);
+                    let mut index = Index::new(location.to_path_buf());
                     index.update(Resource {
                         path: PathBuf::from("assets/example.png"),
                         url: "https://example.com/example.png".to_string(),
@@ -447,7 +444,7 @@ async fn run_web_resource_with_index_existing_forced() -> Result<()> {
                 .once()
                 .with(eq(PathBuf::from("web-resource-index.toml")))
                 .returning(|location| {
-                    let mut index = Index::new(location);
+                    let mut index = Index::new(location.to_path_buf());
                     index.update(Resource {
                         path: PathBuf::from("assets/example.png"),
                         url: "https://example.com/example.png".to_string(),
@@ -518,7 +515,7 @@ async fn run_web_resource_with_index_outdated() -> Result<()> {
                 .once()
                 .with(eq(PathBuf::from("web-resource-index.toml")))
                 .returning(|location| {
-                    let mut index = Index::new(location);
+                    let mut index = Index::new(location.to_path_buf());
                     index.update(Resource {
                         path: PathBuf::from("assets/example.png"),
                         url: "https://example.com/example-old.png".to_string(),

--- a/tests/web_resource_test.rs
+++ b/tests/web_resource_test.rs
@@ -7,59 +7,83 @@ use typst_preprocess::error::Result;
 use typst_preprocess::manifest::PrequeryManifest;
 use typst_preprocess::preprocessor::PreprocessorMap;
 use typst_preprocess::query::Query;
-use typst_preprocess::web_resource::{MockWorld, WebResourceFactory};
+use typst_preprocess::web_resource::{MockWorld, MockWorld_NewContext, WebResourceFactory};
 use typst_preprocess::world::MockWorld as MainMockWorld;
+
+struct WebResourceTest {
+    pub _ctx: MockWorld_NewContext,
+    pub world: MainMockWorld,
+}
+
+impl WebResourceTest {
+    pub fn new(
+        args: &'static [&'static str],
+        manifest: &'static str,
+        query: Query,
+        query_result: &'static [u8],
+        cfg_world: impl Fn(&mut MockWorld) + Send + 'static,
+    ) -> Self {
+        let ctx = MockWorld::new_context();
+        ctx.expect().returning(move |main| {
+            let mut world = MockWorld::default();
+            world.expect_main().return_const(main);
+            cfg_world(&mut world);
+            world
+        });
+
+        let mut world = MainMockWorld::new();
+        world.expect_preprocessors().return_const({
+            let mut preprocessors = PreprocessorMap::new();
+            preprocessors.register(WebResourceFactory::<MockWorld>::new());
+            preprocessors
+        });
+        world
+            .expect_arguments()
+            .return_const(CliArguments::parse_from(args));
+        world
+            .expect_read_typst_toml()
+            .returning(|| PrequeryManifest::parse(manifest));
+
+        world
+            .expect_query()
+            .with(eq(query))
+            .returning(|_| Ok(query_result.to_vec()));
+
+        Self { _ctx: ctx, world }
+    }
+
+    pub async fn run(self) -> Result<()> {
+        run(self.world).await
+    }
+}
 
 #[tokio::test]
 async fn run_web_resource() -> Result<()> {
-    // prepare the web resource mock world
-    let ctx = MockWorld::new_context();
-    ctx.expect().returning(|main| {
-        let mut world = MockWorld::default();
-        world.expect_main().return_const(main);
-        // no index specified in the manifest
-        world.expect_read_index().never();
-        world.expect_write_index().never();
+    WebResourceTest::new(
+        &["typst-preprocess", "input.typ"],
+        r#"
+        [package]
+        name = "test"
+        version = "0.0.1"
+        entrypoint = "main.typ"
 
-        world
-    });
-
-    // mock world that contains the preprocessor and basic setup
-    let mut world = MainMockWorld::new();
-    world.expect_preprocessors().return_const({
-        let mut preprocessors = PreprocessorMap::new();
-        preprocessors.register(WebResourceFactory::<MockWorld>::new());
-        preprocessors
-    });
-    world
-        .expect_arguments()
-        .return_const(CliArguments::parse_from(&["typst-preprocess", "input.typ"]));
-    world.expect_read_typst_toml().returning(|| {
-        PrequeryManifest::parse(
-            r#"
-            [package]
-            name = "test"
-            version = "0.0.1"
-            entrypoint = "main.typ"
-
-            [[tool.prequery.jobs]]
-            name = "download"
-            kind = "web-resource"
-            "#,
-        )
-    });
-
-    // mock the query result
-    world
-        .expect_query()
-        .with(eq(Query {
+        [[tool.prequery.jobs]]
+        name = "download"
+        kind = "web-resource"
+        "#,
+        Query {
             selector: "<web-resource>".to_string(),
             field: Some("value".to_string()),
             one: false,
             inputs: Default::default(),
-        }))
-        .returning(|_| Ok(br#"[]"#.to_vec()));
-
-    // run the world
-    run(world).await
+        },
+        br#"[]"#,
+        |world| {
+            // no index specified in the manifest
+            world.expect_read_index().never();
+            world.expect_write_index().never();
+        },
+    )
+    .run()
+    .await
 }

--- a/tests/web_resource_test.rs
+++ b/tests/web_resource_test.rs
@@ -64,6 +64,8 @@ impl WebResourceTest {
     }
 }
 
+/// Run the web resource preprocessor without any resources and no index.
+/// No downloads should happen, and no index should be saved.
 #[tokio::test]
 #[serial(web_resource)]
 async fn run_web_resource_no_resources_no_index() -> Result<()> {
@@ -100,6 +102,8 @@ async fn run_web_resource_no_resources_no_index() -> Result<()> {
     .await
 }
 
+/// Run the web resource preprocessor without any resources and an index.
+/// No downloads should happen, but the index should be saved.
 #[tokio::test]
 #[serial(web_resource)]
 async fn run_web_resource_no_resources_with_index() -> Result<()> {
@@ -144,6 +148,8 @@ async fn run_web_resource_no_resources_with_index() -> Result<()> {
     .await
 }
 
+/// Run the web resource preprocessor with one resource and no index.
+/// The resource does not exist locally and should be downloaded.
 #[tokio::test]
 #[serial(web_resource)]
 async fn run_web_resource_no_index_missing() -> Result<()> {
@@ -190,6 +196,8 @@ async fn run_web_resource_no_index_missing() -> Result<()> {
     .await
 }
 
+/// Run the web resource preprocessor with one resource and no index.
+/// The resource exists locally and should not be downloaded.
 #[tokio::test]
 #[serial(web_resource)]
 async fn run_web_resource_no_index_existing() -> Result<()> {
@@ -229,6 +237,8 @@ async fn run_web_resource_no_index_existing() -> Result<()> {
     .await
 }
 
+/// Run the web resource preprocessor with one resource and no index.
+/// The resource exists locally and should be re-downloaded according to the manifest.
 #[tokio::test]
 #[serial(web_resource)]
 async fn run_web_resource_no_index_existing_forced() -> Result<()> {
@@ -276,6 +286,9 @@ async fn run_web_resource_no_index_existing_forced() -> Result<()> {
     .await
 }
 
+/// Run the web resource preprocessor with one resource and an index.
+/// The resource does not exist locally and should be downloaded.
+/// The index should be saved with the downloaded resource in it.
 #[tokio::test]
 #[serial(web_resource)]
 async fn run_web_resource_with_index_missing() -> Result<()> {
@@ -337,6 +350,9 @@ async fn run_web_resource_with_index_missing() -> Result<()> {
     .await
 }
 
+/// Run the web resource preprocessor with one resource and an index.
+/// The resource exists locally and should not be downloaded.
+/// The index should be saved with the downloaded resource in it (no change).
 #[tokio::test]
 #[serial(web_resource)]
 async fn run_web_resource_with_index_existing() -> Result<()> {
@@ -398,6 +414,9 @@ async fn run_web_resource_with_index_existing() -> Result<()> {
     .await
 }
 
+/// Run the web resource preprocessor with one resource and an index.
+/// The resource exists locally and should be re-downloaded according to the manifest.
+/// The index should be saved with the downloaded resource in it (no change).
 #[tokio::test]
 #[serial(web_resource)]
 async fn run_web_resource_with_index_existing_forced() -> Result<()> {
@@ -467,6 +486,9 @@ async fn run_web_resource_with_index_existing_forced() -> Result<()> {
     .await
 }
 
+/// Run the web resource preprocessor with one resource and an index.
+/// The resource exists locally and should be re-downloaded because the URL has changed.
+/// The index should be saved with the downloaded resource in it (changed URL).
 #[tokio::test]
 #[serial(web_resource)]
 async fn run_web_resource_with_index_outdated() -> Result<()> {

--- a/tests/web_resource_test.rs
+++ b/tests/web_resource_test.rs
@@ -49,7 +49,7 @@ impl WebResourceTest {
             .returning(|| PrequeryManifest::parse(manifest));
 
         world
-            .expect_query()
+            .expect_query_impl()
             .with(eq(query))
             .returning(|_| Ok(query_result.to_vec()));
 

--- a/tests/web_resource_test.rs
+++ b/tests/web_resource_test.rs
@@ -1,0 +1,65 @@
+use clap::Parser;
+
+use mockall::predicate::eq;
+use typst_preprocess::args::CliArguments;
+use typst_preprocess::entry::run;
+use typst_preprocess::error::Result;
+use typst_preprocess::manifest::PrequeryManifest;
+use typst_preprocess::preprocessor::PreprocessorMap;
+use typst_preprocess::query::Query;
+use typst_preprocess::web_resource::{MockWorld, WebResourceFactory};
+use typst_preprocess::world::MockWorld as MainMockWorld;
+
+#[tokio::test]
+async fn run_web_resource() -> Result<()> {
+    // prepare the web resource mock world
+    let ctx = MockWorld::new_context();
+    ctx.expect().returning(|main| {
+        let mut world = MockWorld::default();
+        world.expect_main().return_const(main);
+        // no index specified in the manifest
+        world.expect_read_index().never();
+        world.expect_write_index().never();
+
+        world
+    });
+
+    // mock world that contains the preprocessor and basic setup
+    let mut world = MainMockWorld::new();
+    world.expect_preprocessors().return_const({
+        let mut preprocessors = PreprocessorMap::new();
+        preprocessors.register(WebResourceFactory::<MockWorld>::new());
+        preprocessors
+    });
+    world
+        .expect_arguments()
+        .return_const(CliArguments::parse_from(&["typst-preprocess", "input.typ"]));
+    world.expect_read_typst_toml().returning(|| {
+        PrequeryManifest::parse(
+            r#"
+            [package]
+            name = "test"
+            version = "0.0.1"
+            entrypoint = "main.typ"
+
+            [[tool.prequery.jobs]]
+            name = "download"
+            kind = "web-resource"
+            "#,
+        )
+    });
+
+    // mock the query result
+    world
+        .expect_query()
+        .with(eq(Query {
+            selector: "<web-resource>".to_string(),
+            field: Some("value".to_string()),
+            one: false,
+            inputs: Default::default(),
+        }))
+        .returning(|_| Ok(br#"[]"#.to_vec()));
+
+    // run the world
+    run(world).await
+}


### PR DESCRIPTION
This PR adds traits `World` and `web_resource::World` that mediate between the preprocessors and the outside world. These are mockable using `mockall`, so that preprocessor runs can be tested without interacting with the file system or network.